### PR TITLE
fix(ci): pin Trivy scanner to a published release version

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -103,6 +103,11 @@ jobs:
           image-ref: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           format: 'sarif'
           output: 'trivy-results-${{ env.IMAGE_TAG }}.sarif'
+          # Pin the Trivy binary to a currently-published release. The action's
+          # bundled default (v0.65.0) was removed from GitHub releases, so
+          # setup-trivy could no longer download it and every build job failed.
+          # Renovate keeps this pinned to a release that still exists.
+          version: 'v0.72.0' # trivy-version
 
       - name: Upload Trivy results to GitHub Security tab
         if: always()

--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,16 @@
       "depNameTemplate": "https://gitlab.xiph.org/xiph/speex.git",
       "packageNameTemplate": "xiph/speex",
       "extractVersionTemplate": "^(?<version>Speex-.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinned Trivy scanner binary version in build workflow",
+      "managerFilePatterns": ["/^\\.github/workflows/build-test-push\\.yml$/"],
+      "matchStrings": [
+        "version: '(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)' # trivy-version"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "aquasecurity/trivy"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Description

The **Build, Test & Push** workflow has been failing on every PR (all 17 build variants) since the Trivy release cleanup. The Docker image builds fine — the failure is in the **Trivy vulnerability scan** step, which could not install its scanner binary.

`aquasecurity/trivy-action@v0.33.1` bundles a default Trivy binary version of **`v0.65.0`**. Trivy removed all release artifacts older than `v0.69.2` from GitHub releases, so `setup-trivy` resolves the tag but then exits `1` on the missing download. Because the scan never runs, no `.sarif` file is produced, and the subsequent `upload-sarif` step fails with `Path does not exist: trivy-results-<variant>.sarif`.

Relevant CI log excerpt:

```
installing Trivy binary
aquasecurity/trivy info checking GitHub for tag 'v0.65.0'
aquasecurity/trivy info found version: 0.65.0 for v0.65.0/Linux/64bit
##[error]Process completed with exit code 1.
...
##[error]Path does not exist: trivy-results-1_0a_va_loc-voron.sarif
```

References: [trivy-action#516](https://github.com/aquasecurity/trivy-action/issues/516), [trivy discussion #10330 "Older releases become uninstallable"](https://github.com/aquasecurity/trivy/discussions/10330), [trivy discussion #10276 "Installation script broken due to deleted releases"](https://github.com/aquasecurity/trivy/discussions/10276).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD improvement

## Related Issues

Fixes the failing `Build, Test & Push` workflow (no tracking issue).

## Changes Made

- Pin the Trivy binary to `v0.72.0` (current published release) via the action's `version` input on the scan step in `.github/workflows/build-test-push.yml`.
- Add a Renovate `customManager` (regex) tracking the `github-releases` datasource for `aquasecurity/trivy`, so the pin automatically follows a release that still exists — the `github-releases` datasource only lists releases whose artifacts are present, preventing this exact breakage from recurring.

## Testing

- [ ] Tested locally with `./scripts/dev-up.sh`
- [ ] Ran Dockerfile linter (`hadolint`)

> **Note on local testing:** the full image harness (`docker build` → `container-structure-test` → health check) could not be run in the automated environment because pulling `alpine:3.22` is blocked there (Docker Hub blob CDN egress restriction), so no image could be built. This change touches only CI configuration — not the `Dockerfile` or the image — and the Docker build step already succeeds in CI; only the Trivy step was failing. The full harness (build + structure tests + Trivy scan) will run on this PR and is the authoritative check.

Validation performed:

- `renovate.json` validated as JSON; `build-test-push.yml` validated as YAML.
- The new Renovate regex was tested against the workflow file and correctly extracts `v0.72.0` as `currentValue`.
- Confirmed `v0.72.0` is the current latest Trivy release (published 2026-06-30) and that the action already supports the `version` input.

### Test Environment

- Docker version: n/a (image build blocked by environment egress policy)
- Docker Compose version: n/a
- Operating system: Ubuntu (CI runner: ubuntu-latest)
- Image tag tested: n/a — CI-config-only change

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

## Additional Notes

The Trivy scan step has no `exit-code` input, so it only publishes a SARIF report to the Security tab and never fails the job on findings — bumping the scanner version cannot break the build on newly-detected CVEs.

The pinned `aquasecurity/trivy-action` SHA (`b6643a2`, v0.33.1) is intentionally **not** changed: it predates the March 2026 `trivy-action`/`setup-trivy` tag-hijack supply-chain incident and is already vetted. This PR only overrides the Trivy **binary** version it downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019P2xLyyRwFHYUZ3juN1Fj4

---
_Generated by [Claude Code](https://claude.ai/code/session_019P2xLyyRwFHYUZ3juN1Fj4)_