### PR TITLE
docs: scope CI badges to main branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Call of Duty 2 server meets docker
 
-[![Lint](https://github.com/bgauduch/call-of-duty-2-docker-server/workflows/Lint/badge.svg)](https://github.com/bgauduch/call-of-duty-2-docker-server/actions?query=workflow%3ALint)
-[![Build, Test & Push](https://github.com/bgauduch/call-of-duty-2-docker-server/workflows/Build%2C%20Test%20%26%20Push/badge.svg)](https://github.com/bgauduch/call-of-duty-2-docker-server/actions?query=workflow%3A%22Build%2C+Test+%26+Push%22)
+[![Lint](https://github.com/bgauduch/call-of-duty-2-docker-server/workflows/Lint/badge.svg?branch=main)](https://github.com/bgauduch/call-of-duty-2-docker-server/actions?query=workflow%3ALint+branch%3Amain)
+[![Build, Test & Push](https://github.com/bgauduch/call-of-duty-2-docker-server/workflows/Build%2C%20Test%20%26%20Push/badge.svg?branch=main)](https://github.com/bgauduch/call-of-duty-2-docker-server/actions?query=workflow%3A%22Build%2C+Test+%26+Push%22+branch%3Amain)
 [![Docker Pulls](https://img.shields.io/docker/pulls/bgauduch/cod2server.svg)](https://hub.docker.com/r/bgauduch/cod2server/)
 
 Launch a minimal & lightweight containarized [Call of Duty 2](https://en.wikipedia.org/wiki/Call_of_Duty_2) multiplayer game server, including libcod.


### PR DESCRIPTION
## Why

The **Lint** and **Build, Test & Push** status badges in the README use the default `badge.svg` URL, which reflects the most recent workflow run **across all branches**. When a feature branch fails CI, the badges go red even though `main` is perfectly fine — polluting the badge state for something we don't care about.

## What

Pin both workflow badges to the `main` branch:

- Append `?branch=main` to each `badge.svg` URL so the displayed status only reflects the default branch.
- Add `branch%3Amain` to the badge links so clicking a badge lands on the filtered `main` runs.

The Docker Pulls badge is untouched — it's not a GitHub Actions workflow and has no branch concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPF2Xn5H3pff2qfsJ3AMxh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPF2Xn5H3pff2qfsJ3AMxh)_