### PR TITLE
docs: fix CI badges scoped to main showing "no status"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Call of Duty 2 server meets docker
 
-[![Lint](https://github.com/bgauduch/call-of-duty-2-docker-server/workflows/Lint/badge.svg?branch=main)](https://github.com/bgauduch/call-of-duty-2-docker-server/actions?query=workflow%3ALint+branch%3Amain)
-[![Build, Test & Push](https://github.com/bgauduch/call-of-duty-2-docker-server/workflows/Build%2C%20Test%20%26%20Push/badge.svg?branch=main)](https://github.com/bgauduch/call-of-duty-2-docker-server/actions?query=workflow%3A%22Build%2C+Test+%26+Push%22+branch%3Amain)
+[![Lint](https://github.com/bgauduch/call-of-duty-2-docker-server/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/bgauduch/call-of-duty-2-docker-server/actions/workflows/lint.yml?query=branch%3Amain)
+[![Build, Test & Push](https://github.com/bgauduch/call-of-duty-2-docker-server/actions/workflows/build-test-push.yml/badge.svg?branch=main)](https://github.com/bgauduch/call-of-duty-2-docker-server/actions/workflows/build-test-push.yml?query=branch%3Amain)
 [![Docker Pulls](https://img.shields.io/docker/pulls/bgauduch/cod2server.svg)](https://hub.docker.com/r/bgauduch/cod2server/)
 
 Launch a minimal & lightweight containarized [Call of Duty 2](https://en.wikipedia.org/wiki/Call_of_Duty_2) multiplayer game server, including libcod.


### PR DESCRIPTION
## Why

Follow-up to #161. That PR scoped the **Lint** and **Build, Test & Push** badges to `main` by appending `?branch=main`, but kept the legacy `/workflows/<name>/badge.svg` URL format — which does not reliably honor the `?branch=` query param. The result: both badges rendered as **"no status"**.

## What

Switch both workflow badges to the current file-based URL format, which correctly reports the workflow status on `main`:

- `…/actions/workflows/lint.yml/badge.svg?branch=main`
- `…/actions/workflows/build-test-push.yml/badge.svg?branch=main`

The badge links now point at the matching per-workflow run list filtered on `main`. The Docker Pulls badge is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPF2Xn5H3pff2qfsJ3AMxh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPF2Xn5H3pff2qfsJ3AMxh)_