### PR TITLE
ci: satisfy bare-name required checks on build-touching PRs via gate jobs

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -71,14 +71,26 @@ graph TD
    - May fail without game files (expected in CI)
    - Marked as `continue-on-error: true`
 
-5. **push-latest** - Pushes 'latest' tag (main only)
+5. **build-gate / test-structure-gate / test-health-gate** - Required-check gates
+   - Non-matrix jobs that aggregate the matrix job results
+   - Re-report the bare check names required by branch protection on `main`
+     ("Build Docker Images", "Container Structure Tests",
+     "Container Health & Runtime Tests (Optional)")
+   - Needed because matrix jobs only report suffixed names
+     (e.g. `Build Docker Images (1_3, _nodelay_va_loc, ibuddieat)`), which
+     never satisfy the bare-name required checks
+   - The health gate mirrors the optional semantics: a failed health matrix
+     still passes the gate
+   - Keep the gate `name:` values in sync with `skip-build-test-push.yml`
+
+6. **push-latest** - Pushes 'latest' tag (main only)
    - Only runs on successful push to main
    - Downloads and loads default variant image
    - Tags default variant as `latest`
    - Pushes to Docker Hub
    - Creates job summary with deployment details
 
-6. **push-release** - Pushes semantic version tags (releases only)
+7. **push-release** - Pushes semantic version tags (releases only)
    - Only runs on release events
    - Downloads and loads all variant images
    - Uses docker/metadata-action for tag generation

--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -202,6 +202,53 @@ jobs:
           ./tests/test-container-health.sh ${{ needs.setup.outputs.image_name }}:${{ env.IMAGE_TAG }} || true
           echo "Note: Health check may fail without game files - this is expected in CI"
 
+  # Required-check gates: branch protection on `main` requires the bare check
+  # names "Build Docker Images", "Container Structure Tests" and "Container
+  # Health & Runtime Tests (Optional)". The matrix jobs above only ever report
+  # suffixed names like "Build Docker Images (1_3, _nodelay_va_loc, ibuddieat)",
+  # which never satisfy those required checks — on PRs that touch build paths
+  # the bare names would stay "Expected" forever and block the merge (the
+  # skip-build-test-push.yml companion only covers PRs that do NOT touch build
+  # paths). These non-matrix jobs aggregate each matrix and re-report the bare
+  # names as real results.
+  # IMPORTANT: keep the `name:` values in sync with the required status checks
+  # on `main` and with the job names in .github/workflows/skip-build-test-push.yml.
+  build-gate:
+    name: Build Docker Images
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+      - name: Check build matrix result
+        run: |
+          echo "Build matrix result: ${{ needs.build.result }}"
+          test "${{ needs.build.result }}" = "success"
+
+  test-structure-gate:
+    name: Container Structure Tests
+    runs-on: ubuntu-latest
+    needs: test-structure
+    if: always()
+    steps:
+      - name: Check structure tests matrix result
+        run: |
+          echo "Structure tests matrix result: ${{ needs.test-structure.result }}"
+          test "${{ needs.test-structure.result }}" = "success"
+
+  test-health-gate:
+    name: Container Health & Runtime Tests (Optional)
+    runs-on: ubuntu-latest
+    needs: test-health
+    if: always()
+    steps:
+      - name: Check health tests matrix result
+        run: |
+          # Health tests are optional (continue-on-error on the matrix job), so
+          # a failed matrix still passes the gate — only cancelled/skipped fails.
+          result="${{ needs.test-health.result }}"
+          echo "Health tests matrix result: $result"
+          test "$result" = "success" || test "$result" = "failure"
+
   push-latest:
     name: Push Latest Tag
     runs-on: ubuntu-latest

--- a/.github/workflows/skip-build-test-push.yml
+++ b/.github/workflows/skip-build-test-push.yml
@@ -3,19 +3,22 @@ name: Build, Test & Push (skip)
 # Companion "skip" workflow — DO NOT add real build logic here.
 #
 # The real "Build, Test & Push" workflow (build-test-push.yml) is path-filtered:
-# it only runs on PRs that touch build-related files. Its jobs (Build Docker
-# Images, Container Structure Tests, Container Health & Runtime Tests) are
-# configured as *required* status checks on `main`. GitHub leaves a required
-# check that never reports in a permanent "Expected — Waiting for status to be
-# reported" state, which blocks (and prevents auto-merge of) any PR that does not
-# touch build files.
+# it only runs on PRs that touch build-related files. The bare check names
+# "Build Docker Images", "Container Structure Tests" and "Container Health &
+# Runtime Tests (Optional)" are configured as *required* status checks on
+# `main`. GitHub leaves a required check that never reports in a permanent
+# "Expected — Waiting for status to be reported" state, which blocks (and
+# prevents auto-merge of) any PR that does not touch build files.
 #
 # This workflow triggers on the exact complement (`paths-ignore` mirrors the real
 # workflow's `paths`) and re-reports the same job names as trivial successes, so
 # unrelated PRs can satisfy the required checks without building the 17 variants.
+# On PRs that DO touch build files, the real workflow's non-matrix "gate" jobs
+# report those same bare names, since its matrix jobs only report suffixed names
+# ("Build Docker Images (1_3, ...)") that never match the required checks.
 #
 # IMPORTANT: keep the `paths-ignore` list and the job `name:` values in sync with
-# .github/workflows/build-test-push.yml.
+# .github/workflows/build-test-push.yml (both its gate jobs and its `paths`).
 
 on:
   pull_request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ Format: `cod2_lnxded_X_Y[suffix]` (located in [bin/](bin/))
 
 Path-filtered workflows above have companion `skip-*.yml` workflows that report the same *required* status checks as no-op successes for PRs that don't touch the relevant paths. This prevents required-but-skipped checks from getting stuck in a permanent "Expected" state. Keep each `skip-*.yml` `paths-ignore` list and job `name:` values in sync with the real workflow it mirrors.
 
+Because the build/test jobs in [build-test-push.yml](.github/workflows/build-test-push.yml) use a matrix, they only report suffixed check names (e.g. `Build Docker Images (1_3, _nodelay_va_loc, ibuddieat)`), which never satisfy the bare-name required checks. Non-matrix *gate* jobs (`build-gate`, `test-structure-gate`, `test-health-gate`) aggregate each matrix and re-report the bare names on PRs that touch build paths. Keep the gate job `name:` values in sync with the required status checks and with `skip-build-test-push.yml`.
+
 ### Conventional Commits
 
 | Type | Version Bump | Example |


### PR DESCRIPTION
## Description

PRs that touch build-relevant paths (e.g. Renovate updates to `build-test-push.yml`, like #158) can currently never satisfy the required status checks on `main`, even with all checks green. The required checks are the **bare** job names (`Build Docker Images`, `Container Structure Tests`, `Container Health & Runtime Tests (Optional)`), but the real workflow's matrix jobs only ever report **suffixed** check names such as `Build Docker Images (1_3, _nodelay_va_loc, ibuddieat)` — and the `skip-build-test-push.yml` companion (the only thing that reports the bare names today) is correctly excluded via `paths-ignore` on those PRs. Result: the bare-name required checks sit in "Expected — Waiting for status to be reported" forever and block the merge.

This PR adds non-matrix **gate jobs** to the real workflow that aggregate each matrix result and re-report the bare names, so both sides of the path filter now satisfy the required checks. This PR touches `.github/workflows/build-*.yml` itself, so its own checks demonstrate the fix.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Dependency update
- [x] CI/CD improvement

## Related Issues

Unblocks #158 (and any future PR touching build paths). Follow-up to #162.

Scope is deliberately limited to the missing-reporter bug. A separate, pre-existing defect — `skip-*.yml` and the real workflow both reporting the same check names on PRs that touch both filtered and unfiltered paths, where the faster skip job can mask a real failure — is tracked in #166.

## Changes Made

- Add `build-gate`, `test-structure-gate` and `test-health-gate` jobs to `build-test-push.yml`: non-matrix jobs with the exact bare names required by branch protection, each `needs:` its matrix job with `if: always()` and asserting the aggregated result
- `test-health-gate` mirrors the matrix job's `continue-on-error` semantics: a failed health matrix still passes the gate (only cancelled/skipped fails it)
- Update the `skip-build-test-push.yml` rationale comment to document the gate/skip pairing and the name-sync invariant
- Document the gate jobs in `AGENTS.md` and `.github/WORKFLOWS.md`

## Testing

- [ ] Tested locally with `./scripts/dev-up.sh`
- [ ] Server starts successfully
- [ ] Verified server functionality (connection, gameplay, etc.)
- [ ] Ran Dockerfile linter (`hadolint`)
- [ ] Tested with different image tags/configurations

CI-only change — no Dockerfile, scripts or runtime behavior touched. This PR triggers the real build workflow (it touches `.github/workflows/build-*.yml`), so the gate jobs run and report the bare check names on this very PR — the merge box going green here is the end-to-end test.

Verified on head `a82711d`: all three bare names reported from the real workflow run `30692639411` and green — `Build Docker Images`, `Container Structure Tests`, `Container Health & Runtime Tests (Optional)` — alongside all 17 suffixed matrix jobs per stage. Before this change, on #158, those three rows did not exist at all.

### Test Environment

- Docker version: n/a (CI-only change)
- Docker Compose version: n/a
- Operating system: n/a
- Image tag tested: n/a

## Screenshots / Logs

```
PR #158 head af5b683: 59/59 check runs green, yet mergeable_state=blocked —
required contexts "Build Docker Images", "Container Structure Tests" and
"Container Health & Runtime Tests (Optional)" never reported (only matrix-
suffixed names were reported).
```

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published

## Breaking Changes

None.

## Additional Notes

Suggested required status checks on `main` once this lands: `Lint Dockerfile`, `Lint Shell Scripts`, `Build Docker Images`, `Container Structure Tests`. `Container Health & Runtime Tests (Optional)` is `continue-on-error` and its script exits `|| true`, so it can never fail and adds no merge-gating signal. Never require the matrix-suffixed names or the CodeQL/Trivy code-scanning entries.