### PR TITLE
fix: use JSON notation for HEALTHCHECK CMD and bump hadolint-action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run Hadolint
-        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
         with:
           dockerfile: Dockerfile
           failure-threshold: warning

--- a/Dockerfile
+++ b/Dockerfile
@@ -178,8 +178,7 @@ RUN mkdir -p /home/${SERVER_USER}/.callofduty2/main/ \
 # - check server process is running and responsive
 # - check games log are written to file (Uses -e to check symlink/file exists)
 HEALTHCHECK --interval=5s --timeout=1s --start-period=5s --retries=3 \
-  CMD pgrep -x cod2_lnxded > /dev/null && \
-  test -e /home/${SERVER_USER}/.callofduty2/main/games_mp.log || exit 1
+  CMD [ "/bin/sh", "-c", "pgrep -x cod2_lnxded > /dev/null && test -e /home/${SERVER_USER}/.callofduty2/main/games_mp.log || exit 1" ]
 
 # Switch to non-root user
 USER ${SERVER_USER}


### PR DESCRIPTION
hadolint-action v3.4.0 ships hadolint 2.15.x, which extends DL3025 ("Use
arguments JSON notation for CMD and ENTRYPOINT arguments") to HEALTHCHECK
CMD. That is a warning, and the Lint Dockerfile job runs with
`failure-threshold: warning`, so the renovate bump in #167 turned the job
red on an otherwise unchanged Dockerfile.

Rewrite the healthcheck in exec form, wrapping the command in an explicit
`/bin/sh -c` since it relies on shell operators. Behaviour is unchanged:
the final Alpine stage already used the default `/bin/sh -c` shell, and
SERVER_USER is an ENV, so the shell still expands it at runtime.

Bump hadolint-action to v3.4.0 in the same change so CI validates the
Dockerfile against the new linter.

Verified with hadolint 2.15.1 and 2.12.0, both exit 0 at the `warning`
threshold. The remaining DL3066 on `USER ${SERVER_USER}` is info-level
and below the failure threshold.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L9zEpgFtmKxqV9u4oBgsGT